### PR TITLE
Bugfix - NPE in error case and expectedResponseCode

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -80,7 +80,8 @@ dependencies {
     testImplementation "org.amshove.kluent:kluent:$kluentVersion"
     testImplementation "com.squareup.okhttp3:mockwebserver:$okhttpVersion"
     testImplementation "com.h2database:h2:$h2Version"
-
+    testImplementation "io.mockk:mockk:$mockkVersion"
+    
     testRuntime "org.jetbrains.spek:spek-junit-platform-engine:$spekVersion"
 }
 

--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -36,4 +36,5 @@ ext {
     spekVersion = '1.2.1'
     kluentVersion = '1.49'
     h2Version = '1.4.199'
+    mockkVersion = '1.9.3'
 }

--- a/src/main/kotlin/de/smartsquare/squit/report/HtmlReportWriter.kt
+++ b/src/main/kotlin/de/smartsquare/squit/report/HtmlReportWriter.kt
@@ -67,16 +67,7 @@ object HtmlReportWriter {
 
             val bodyDiff = generateDiff(result.expectedLines, result.actualLines, DIFF_FILE_NAME)
             val unifiedDiffForJs = prepareForJs(bodyDiff)
-
-            val unifiedInfoDiffForJs = if (!result.expectedResponseInfo.isDefault) {
-                val expectedInfoLines = result.expectedResponseInfo.toJson().lines()
-                val actualInfo = result.actualInfoLines.joinToString(separator = "\n")
-                val actualInfoLines = SquitResponseInfo.fromJson(actualInfo).toJson().lines()
-                val infoDiff = generateDiff(expectedInfoLines, actualInfoLines, DIFF_INFO_FILE_NAME)
-                prepareForJs(infoDiff)
-            } else {
-                ""
-            }
+            val unifiedInfoDiffForJs = prepareInfoForJs(result)
 
             val descriptionForReplacement = if (result.description == null) "null" else "\"${result.description}\""
                 .replace("\n", HTML_LINE_ENDING)
@@ -101,6 +92,22 @@ object HtmlReportWriter {
         }
 
         Files.write(reportDirectoryPath.resolve("index.html"), document.toString().toByteArray())
+    }
+
+    internal fun prepareInfoForJs(result: SquitResult): String {
+        return if (!result.expectedResponseInfo.isDefault) {
+            val expectedInfoLines = result.expectedResponseInfo.toJson().lines()
+            val actualInfo = result.actualInfoLines.joinToString(separator = "\n")
+            val actualInfoLines = if (actualInfo.isEmpty()) {
+                emptyList()
+            } else {
+                SquitResponseInfo.fromJson(actualInfo).toJson().lines()
+            }
+            val infoDiff = generateDiff(expectedInfoLines, actualInfoLines, DIFF_INFO_FILE_NAME)
+            prepareForJs(infoDiff)
+        } else {
+            ""
+        }
     }
 
     private fun prepareForJs(bodyDiff: List<String>): String {

--- a/src/test/kotlin/de/smartsquare/squit/report/HtmlReportWriterSpek.kt
+++ b/src/test/kotlin/de/smartsquare/squit/report/HtmlReportWriterSpek.kt
@@ -1,0 +1,60 @@
+package de.smartsquare.squit.report
+
+import de.smartsquare.squit.entity.SquitResponseInfo
+import de.smartsquare.squit.entity.SquitResult
+import io.mockk.every
+import io.mockk.mockk
+import org.amshove.kluent.`should be equal to`
+import org.jetbrains.spek.api.Spek
+import org.jetbrains.spek.api.dsl.given
+import org.jetbrains.spek.api.dsl.it
+import org.jetbrains.spek.api.dsl.on
+
+/**
+ * @author Sascha Koch
+ */
+object HtmlReportWriterSpek : Spek({
+
+    val writer = HtmlReportWriter
+
+    given("a squit result with default expected response code") {
+        val result = mockk<SquitResult>()
+        every { result.expectedResponseInfo } returns SquitResponseInfo()
+
+        on("unifiying this to js text") {
+            it("should have an empty diff") {
+                writer.prepareInfoForJs(result) `should be equal to` ""
+            }
+        }
+    }
+
+    given("a squit result with expected response code and no actual info file") {
+        val result = mockk<SquitResult>()
+        every { result.expectedResponseInfo } returns SquitResponseInfo(200)
+        every { result.actualInfoLines } returns emptyList()
+
+        on("unifiying this to js text") {
+            it("should have a correct diff") {
+                writer.prepareInfoForJs(result) `should be equal to` "--- ResultInfo\\n\\\n" +
+                    "+++ ResultInfo\\n\\\n" +
+                    "@@ -1,1 +1,0 @@\\n\\\n" +
+                    "-{\\\"responseCode\\\":200}"
+            }
+        }
+    }
+
+    given("a squit result with expected response code and an actual info file") {
+        val result = mockk<SquitResult>()
+        every { result.expectedResponseInfo } returns SquitResponseInfo(200)
+        every { result.actualInfoLines } returns listOf("{", "\"responseCode\":200", "}")
+
+        on("unifiying this to js text") {
+            it("should have no diff with the response code") {
+                writer.prepareInfoForJs(result) `should be equal to` "--- Result\\n\\\n" +
+                    "+++ Result\\n\\\n" +
+                    "@@ -1 +1 @@\\n\\\n" +
+                    " {\\\"responseCode\\\":200}"
+            }
+        }
+    }
+})


### PR DESCRIPTION
In case no server response was received, the HTML report writer still tried to check the response info file when an expectedResponseCode was set in test.conf.

Error Msg: Execution failed for task ‘:squitTest’.
> Gson().fromJson(json, Sq…ResponseInfo::class.java) must not be null

The fix checks whether an info response is available.