### PR TITLE
Add fix invalid namespaces option for XML canonicalization

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,13 +13,13 @@ jobs:
         java: [ 8, 14 ]
 
     steps:
-      - uses: actions/checkout@v2.3.2
+      - uses: actions/checkout@v2.3.4
       - name: Setup JDK
-        uses: actions/setup-java@v1.4.1
+        uses: actions/setup-java@v1.4.3
         with:
           java-version: ${{ matrix.java }}
       - name: Setup Gradle cache
-        uses: actions/cache@v2.1.0
+        uses: actions/cache@v2.1.4
         with:
           path: ~/.gradle/caches/modules-2
           key: ${{ runner.os }}-${{ matrix.java }}-gradle-${{ hashFiles('**/versions.gradle') }}
@@ -33,7 +33,7 @@ jobs:
         run: .\gradlew.bat build
 
       - name: Store reports
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v2.2.2
         if: always()
         with:
           name: reports-${{ runner.OS }}-${{ matrix.java }}

--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -1,6 +1,6 @@
 ext {
     gradleVersion = '6.6'
-    squitVersion = '3.0.2'
+    squitVersion = '3.0.3'
 
     gradlePublishVersion = '0.12.0'
 

--- a/src/main/kotlin/de/smartsquare/squit/SquitExtension.kt
+++ b/src/main/kotlin/de/smartsquare/squit/SquitExtension.kt
@@ -115,6 +115,18 @@ open class SquitExtension(private val project: Project) {
          */
         @get:Input
         var canonicalize = true
+
+        /**
+         * Whether to try to resolve invalid namespaces on canonicalization (e.g. missing http://)
+         */
+        @get:Input
+        var resolveInvalidNamespaces = false
+
+        /**
+         * The default resolving string for invalid namespaces (only used when resolveInvalidNamespaces is set to true).
+         */
+        @get:Input
+        var resolveNamespaceString = "http://"
     }
 
     /**

--- a/src/main/kotlin/de/smartsquare/squit/SquitPlugin.kt
+++ b/src/main/kotlin/de/smartsquare/squit/SquitPlugin.kt
@@ -43,7 +43,11 @@ class SquitPlugin : Plugin<Project> {
                 it.silent = extension.silent
                 it.ignoreFailures = extension.ignoreFailures
                 it.mediaTypeConfig = MediaTypeConfig(
-                    extension.xml.strict, extension.xml.canonicalize, extension.json.canonicalize
+                    extension.xml.strict,
+                    extension.xml.canonicalize,
+                    extension.json.canonicalize,
+                    extension.xml.resolveInvalidNamespaces,
+                    extension.xml.resolveNamespaceString
                 )
 
                 it.dependsOn("squitPostProcess")

--- a/src/main/kotlin/de/smartsquare/squit/mediatype/MediaTypeConfig.kt
+++ b/src/main/kotlin/de/smartsquare/squit/mediatype/MediaTypeConfig.kt
@@ -12,5 +12,7 @@ import org.gradle.api.tasks.Input
 data class MediaTypeConfig(
     @get:Input val xmlStrict: Boolean = true,
     @get:Input val xmlCanonicalize: Boolean = true,
-    @get:Input val jsonCanonicalize: Boolean = true
+    @get:Input val jsonCanonicalize: Boolean = true,
+    @get:Input val resolveInvalidNamespaces: Boolean = false,
+    @get:Input val resolveNamespaceString: String = "http://"
 )

--- a/src/test/kotlin/de/smartsquare/squit/mediatype/xml/XmlCanonicalizerSpek.kt
+++ b/src/test/kotlin/de/smartsquare/squit/mediatype/xml/XmlCanonicalizerSpek.kt
@@ -64,5 +64,34 @@ object XmlCanonicalizerSpek : Spek({
                 result shouldBeEqualTo structure
             }
         }
+
+        on("canonicalize an xml structure with resolving invalid namespaces") {
+            // language=xml
+            val structure = """
+                <ns3:test xmlns:ns3='w3.org/2001/XMLSchema-instance'>
+                    <hello b="b">Abc</hello>
+                </ns3:test>
+            """.trimIndent()
+
+            it("should produce a valid result") {
+                val result = canonicalizer.canonicalize(
+                    structure, MediaTypeConfig(
+                    xmlStrict = false,
+                    xmlCanonicalize = true,
+                    jsonCanonicalize = false,
+                    resolveInvalidNamespaces = true
+                )
+                )
+
+                // language=xml
+                val expected = """<?xml version="1.0" encoding="UTF-8"?>
+
+                <ns3:test xmlns:ns3="http://w3.org/2001/XMLSchema-instance">
+                <hello b="b">Abc</hello>
+                </ns3:test>""".trimIndent()
+
+                result shouldBeEqualTo expected
+            }
+        }
     }
 })

--- a/src/test/kotlin/de/smartsquare/squit/mediatype/xml/XmlCanonicalizerSpek.kt
+++ b/src/test/kotlin/de/smartsquare/squit/mediatype/xml/XmlCanonicalizerSpek.kt
@@ -84,13 +84,16 @@ object XmlCanonicalizerSpek : Spek({
                 )
 
                 // language=xml
-                val expected = """<?xml version="1.0" encoding="UTF-8"?>
+                val expected = """
+                    <?xml version="1.0" encoding="UTF-8"?>
 
-                <ns3:test xmlns:ns3="http://w3.org/2001/XMLSchema-instance">
-                <hello b="b">Abc</hello>
-                </ns3:test>""".trimIndent()
+                    <ns3:test xmlns:ns3="http://w3.org/2001/XMLSchema-instance">
+                      <hello b="b">Abc</hello>
+                    </ns3:test>
 
-                result shouldBeEqualTo expected
+                """.trimIndent()
+
+                result.trim() shouldBeEqualTo expected.trim()
             }
         }
     }


### PR DESCRIPTION
The Canonicalization process can fail on certain namespaces, e.g. when they are missing a proper route like http://
An additional Gradle option allows to resolve the namespaces without having to adapt the resources for squit testing.