### PR TITLE
Escape linebreaks in html diff view

### DIFF
--- a/src/main/kotlin/de/smartsquare/squit/report/HtmlReportWriter.kt
+++ b/src/main/kotlin/de/smartsquare/squit/report/HtmlReportWriter.kt
@@ -146,6 +146,7 @@ class HtmlReportWriter(private val logger: Logger) {
         return bodyDiff
             .map { it.replace(Regex("(?<!\\\\)'"), Regex.escapeReplacement("\\'")) }
             .map { it.replace(Regex("(?<!\\\\)\""), Regex.escapeReplacement("\\\"")) }
+            .map { it.replace(Regex("\\\\n"), Regex.escapeReplacement("\\\\n")) }
             .joinToString(HTML_LINE_ENDING)
     }
 


### PR DESCRIPTION
Unescaped line breaks caused display issues in html diff as message got cut after `\n`.

Fixes https://github.com/SmartsquareGmbH/squit/issues/14